### PR TITLE
Corrected template to pluralize entity name.

### DIFF
--- a/crud-module/templates/tests/server/_.server.routes.tests.js
+++ b/crud-module/templates/tests/server/_.server.routes.tests.js
@@ -79,10 +79,10 @@ describe('<%= humanizedSingularName %> CRUD tests', function () {
 
             // Get a list of <%= humanizedPluralName %>
             agent.get('/api/<%= camelizedPluralName %>')
-              .end(function (<%= camelizedSingularName %>sGetErr, <%= camelizedSingularName %>sGetRes) {
-                // Handle <%= humanizedSingularName %> save error
-                if (<%= camelizedSingularName %>sGetErr) {
-                  return done(<%= camelizedSingularName %>sGetErr);
+              .end(function (<%= camelizedPluralName %>GetErr, <%= camelizedPluralName %>GetRes) {
+                // Handle <%= humanizedPluralName %> save error
+                if (<%= camelizedPluralName %>GetErr) {
+                  return done(<%= camelizedPluralName %>GetErr);
                 }
 
                 // Get <%= humanizedPluralName %> list


### PR DESCRIPTION
Correcting the template where it attempts to pluralize the entity name of the crud module.  The template was incorrectly concatenating an 's' onto the end of the singular entity name where the inflections module had actually mapped the plural correctly.  The correction essentially changes the template to use the pluralized versions of the entity name.  This issue is particularly important because it is reproducable by following the meanjs.org superhero / superheroes video tutorial on youtube.com.
